### PR TITLE
add STAC time slider example to notebook

### DIFF
--- a/docs/notebooks/22_time_slider.ipynb
+++ b/docs/notebooks/22_time_slider.ipynb
@@ -114,11 +114,76 @@
     "layers_dict = leafmap.basemap_xyz_tiles()\n",
     "m.add_time_slider(layers_dict, time_interval=1)\n",
     "m"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the time slider to visualize COG assets found within STAC items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "metadata": {
-    "scrolled": false
-   }
+   "source": [
+    "import ipyleaflet\n",
+    "import json\n",
+    "import requests\n",
+    "\n",
+    "stac_api = \"https://earth-search.aws.element84.com/v0\"\n",
+    "search_endpoint = f\"{stac_api}/search\"\n",
+    "\n",
+    "collection = \"sentinel-s2-l2a-cogs\"\n",
+    "payload = {\n",
+    "    \"bbox\": [\n",
+    "        -102.83340454101562, 49.77860375256143, -102.41043090820312, 50.05273014900257\n",
+    "    ],\n",
+    "    \"datetime\": \"2021-07-01T00:00:00Z/2021-10-01T12:31:12Z\",\n",
+    "    \"collections\": [collection],\n",
+    "    \"limit\": 10,\n",
+    "    \"query\": {\n",
+    "      \"eo:cloud_cover\": {\n",
+    "          \"gte\": 0,\n",
+    "          \"lte\": 10\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "headers = {\n",
+    "  'Content-Type': 'application/json'\n",
+    "}\n",
+    "\n",
+    "response = requests.request(\"POST\", search_endpoint, headers=headers, data=json.dumps(payload))\n",
+    "\n",
+    "features = response.json()[\"features\"]\n",
+    "features.sort(key=lambda x: x[\"properties\"][\"datetime\"], reverse=False)\n",
+    "\n",
+    "layers_dict = {}\n",
+    "for feature in features:\n",
+    "    feature_id = feature[\"id\"]\n",
+    "    print(feature_id)\n",
+    "    \n",
+    "    url = leafmap.stac_tile(f\"{stac_api}/collections/{collection}/items/{feature_id}\", bands=[\"visual\"])\n",
+    "    tile_layer = ipyleaflet.TileLayer(\n",
+    "        url=url,\n",
+    "        name=feature_id,\n",
+    "    )\n",
+    "    layers_dict[feature_id] = tile_layer\n",
+    "    \n",
+    "m = leafmap.Map(center=[50.093079, -103.152825], zoom=11)\n",
+    "m.add_time_slider(layers_dict, time_interval=2)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/22_time_slider.ipynb
+++ b/docs/notebooks/22_time_slider.ipynb
@@ -108,6 +108,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m = leafmap.Map()\n",
     "m.clear_layers()\n",


### PR DESCRIPTION
This PR adds an example to the time slider notebook, which queries a STAC API (https://earth-search.aws.element84.com/v0) for STAC items, containing COG assets, and assembles the results into a time slider.