### PR TITLE
added geopandas to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bqplot
 colour
 folium>=0.11.0
 geojson
+geopandas
 googledrivedownloader
 here-map-widget-for-jupyter>=1.1.1
 ipyevents<=0.9.0


### PR DESCRIPTION
using 

`!pip install leafmap`

and then 

```
import leafmap
print(leafmap.__version__) # 0.5.4
from leafmap import leafmap
m = leafmap.Map()
m.add_point_layer("../data/us_cities.geojson", popup="name", layer_name="US Cities")
m
```

raises

```
---------------------------------------------------------------------------

ModuleNotFoundError                       Traceback (most recent call last)

/usr/local/lib/python3.7/dist-packages/leafmap/common.py in check_package(name, URL)
    149     try:
--> 150         __import__(name.lower())
    151     except Exception:

ModuleNotFoundError: No module named 'geopandas'


During handling of the above exception, another exception occurred:

ImportError                               Traceback (most recent call last)

2 frames

/usr/local/lib/python3.7/dist-packages/leafmap/common.py in check_package(name, URL)
    151     except Exception:
    152         raise ImportError(
--> 153             f"{name} is not installed. Please install it before proceeding. {URL}"
    154         )
    155 

ImportError: geopandas is not installed. Please install it before proceeding. https://geopandas.org


---------------------------------------------------------------------------
NOTE: If your import is failing due to a missing package, you can
manually install dependencies using either !pip or !apt.

To view examples of installing some common dependencies, click the
"Open Examples" button below.
---------------------------------------------------------------------------
```

My best guess is that the dependency on `geopandas` just slipped through the cracks during a version update.