### PR TITLE
Add support for local raster datasets and remote COGs using localtileserver 

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ The leafmap package has an optional dependency - [geopandas](https://geopandas.o
     conda install geopandas
     conda install mamba -c conda-forge
     mamba install leafmap xarray_leaflet -c conda-forge
-    pip install keplergl
+    pip install keplergl localtileserver
 ```
 
 Optionally, you can install some [Jupyter notebook extensions](https://github.com/ipython-contrib/jupyter_contrib_nbextensions), which can improve your productivity in the notebook environment. Some useful extensions include Table of Contents, Gist-it, Autopep8, Variable Inspector, etc. See this [post](https://towardsdatascience.com/jupyter-notebook-extensions-517fa69d2231) for more information.

--- a/docs/notebooks/32_local_tile.ipynb
+++ b/docs/notebooks/32_local_tile.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://binder.pangeo.io/badge_logo.svg)](https://gishub.org/leafmap-pangeo)\n",
+    "\n",
+    "**Using local raster datasets or remote Cloud Optimized GeoTIFFs (COG) with leafmap**\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) and [localtileserver](https://github.com/banesullivan/localtileserver) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install leafmap localtileserver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specify input raster datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_dir = os.path.expanduser('~/Downloads')\n",
+    "\n",
+    "if not os.path.exists(out_dir):\n",
+    "    os.makedirs(out_dir)\n",
+    "\n",
+    "dem = os.path.join(out_dir, 'dem.tif')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download samples raster datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(dem):\n",
+    "    dem_url = 'https://drive.google.com/file/d/1vRkAWQYsLWCi6vcTMk8vLxoXMFbdMFn8/view?usp=sharing'\n",
+    "    leafmap.download_from_gdrive(dem_url, 'dem.tif', out_dir, unzip=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add local raster datasets to the map. The available palettes can be found at https://jiffyclub.github.io/palettable/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_local_tile(dem, palette='matplotlib.Viridis_10', layer_name=\"DEM\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add a remote Cloud Optimized GeoTIFF(COG) to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_remote_tile(url, layer_name=\"CA Fire\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Table of Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "313px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/notebooks/32_local_tile.ipynb
+++ b/examples/notebooks/32_local_tile.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://binder.pangeo.io/badge_logo.svg)](https://gishub.org/leafmap-pangeo)\n",
+    "\n",
+    "**Using local raster datasets or remote Cloud Optimized GeoTIFFs (COG) with leafmap**\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) and [localtileserver](https://github.com/banesullivan/localtileserver) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install leafmap localtileserver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specify input raster datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_dir = os.path.expanduser('~/Downloads')\n",
+    "\n",
+    "if not os.path.exists(out_dir):\n",
+    "    os.makedirs(out_dir)\n",
+    "\n",
+    "dem = os.path.join(out_dir, 'dem.tif')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download samples raster datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(dem):\n",
+    "    dem_url = 'https://drive.google.com/file/d/1vRkAWQYsLWCi6vcTMk8vLxoXMFbdMFn8/view?usp=sharing'\n",
+    "    leafmap.download_from_gdrive(dem_url, 'dem.tif', out_dir, unzip=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add local raster datasets to the map. The available palettes can be found at https://jiffyclub.github.io/palettable/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_local_tile(dem, palette='matplotlib.Viridis_10', layer_name=\"DEM\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add a remote Cloud Optimized GeoTIFF(COG) to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_remote_tile(url, layer_name=\"CA Fire\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Table of Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "313px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -299,6 +299,86 @@ class Map(folium.Map):
         except Exception as e:
             raise Exception(e)
 
+    def add_local_tile(
+        self,
+        source,
+        band=None,
+        palette=None,
+        vmin=None,
+        vmax=None,
+        nodata=None,
+        attribution=None,
+        layer_name=None,
+        **kwargs,
+    ):
+        """Add a local raster dataset to the map.
+
+        Args:
+            source (str): The path to the GeoTIFF file or the URL of the Cloud Optimized GeoTIFF.
+            band (int, optional): The band to use. Band indexing starts at 1. Defaults to None.
+            palette (str, optional): The name of the color palette from `palettable` to use when plotting a single band. See https://jiffyclub.github.io/palettable. Default is greyscale
+            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to None.
+        """
+
+        tile, center = get_local_tile_layer(
+            source,
+            band=band,
+            palette=palette,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+            attribution=attribution,
+            tile_format="folium",
+            layer_name=layer_name,
+            get_center=True,
+            **kwargs,
+        )
+        self.add_layer(tile)
+        self.set_center(center[1], center[0], 10)
+
+    def add_remote_tile(
+        self,
+        source,
+        band=None,
+        palette=None,
+        vmin=None,
+        vmax=None,
+        nodata=None,
+        attribution=None,
+        layer_name=None,
+        **kwargs,
+    ):
+        """Add a remote Cloud Optimized GeoTIFF (COG) to the map.
+
+        Args:
+            source (str): The path to the remote Cloud Optimized GeoTIFF.
+            band (int, optional): The band to use. Band indexing starts at 1. Defaults to None.
+            palette (str, optional): The name of the color palette from `palettable` to use when plotting a single band. See https://jiffyclub.github.io/palettable. Default is greyscale
+            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to None.
+        """
+        if isinstance(source, str) and source.startswith("http"):
+            self.add_local_tile(
+                source,
+                band=band,
+                palette=palette,
+                vmin=vmin,
+                vmax=vmax,
+                nodata=nodata,
+                attribution=attribution,
+                layer_name=layer_name,
+                **kwargs,
+            )
+        else:
+            raise Exception("The source must be a URL.")
+
     def add_heatmap(
         self,
         filepath=None,

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1557,6 +1557,85 @@ class Map(ipyleaflet.Map):
         for tool in toolbar_grid.children:
             tool.value = False
 
+    def add_local_tile(
+        self,
+        source,
+        band=None,
+        palette=None,
+        vmin=None,
+        vmax=None,
+        nodata=None,
+        attribution=None,
+        layer_name=None,
+        **kwargs,
+    ):
+        """Add a local raster dataset to the map.
+
+        Args:
+            source (str): The path to the GeoTIFF file or the URL of the Cloud Optimized GeoTIFF.
+            band (int, optional): The band to use. Band indexing starts at 1. Defaults to None.
+            palette (str, optional): The name of the color palette from `palettable` to use when plotting a single band. See https://jiffyclub.github.io/palettable. Default is greyscale
+            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to None.
+        """
+
+        tile, center = get_local_tile_layer(
+            source,
+            band=band,
+            palette=palette,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+            attribution=attribution,
+            layer_name=layer_name,
+            get_center=True,
+            **kwargs,
+        )
+        self.add_layer(tile)
+        self.set_center(center[1], center[0], 10)
+
+    def add_remote_tile(
+        self,
+        source,
+        band=None,
+        palette=None,
+        vmin=None,
+        vmax=None,
+        nodata=None,
+        attribution=None,
+        layer_name=None,
+        **kwargs,
+    ):
+        """Add a remote Cloud Optimized GeoTIFF (COG) to the map.
+
+        Args:
+            source (str): The path to the remote Cloud Optimized GeoTIFF.
+            band (int, optional): The band to use. Band indexing starts at 1. Defaults to None.
+            palette (str, optional): The name of the color palette from `palettable` to use when plotting a single band. See https://jiffyclub.github.io/palettable. Default is greyscale
+            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to None.
+        """
+        if isinstance(source, str) and source.startswith("http"):
+            self.add_local_tile(
+                source,
+                band=band,
+                palette=palette,
+                vmin=vmin,
+                vmax=vmax,
+                nodata=nodata,
+                attribution=attribution,
+                layer_name=layer_name,
+                **kwargs,
+            )
+        else:
+            raise Exception("The source must be a URL.")
+
     def add_raster(
         self,
         image,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,3 +110,4 @@ nav:
           - notebooks/29_pydeck.ipynb
           - notebooks/30_census_data.ipynb
           - notebooks/31_search_basemaps.ipynb
+          - notebooks/32_local_tile.ipynb


### PR DESCRIPTION
Built upon the amazing [localtileserver](https://github.com/banesullivan/localtileserver) package by @banesullivan, leafmap now supports loading local raster dataset and remote Cloud Optimized GeoTIFF (COG) with only one line of code. 

It supports both the ipyleaflet and folium plotting backends. Use either `import leafmap` or `import leafmap.foliumap as leafmap`. The remaining code stays the same. 

**Add a local raster dataset**
```python
import leafmap
m = leafmap.Map()
m.add_local_tile('dem.tif', palette='matplotlib.Viridis_10', layer_name="DEM")
m
```

**Add a remote COG**
```python
import leafmap
m = leafmap.Map()
url = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'
m.add_remote_tile(url, layer_name="CA Fire")
m
```
Local tile:
![image](https://user-images.githubusercontent.com/5016453/143669185-e47cfde4-7c93-469a-b373-edfdb9b06322.png)

Remote COG:
![image](https://user-images.githubusercontent.com/5016453/143669211-a2d72ff8-8b47-43d9-9c10-af4cfe78b2a8.png)
