### PR TITLE
Replace ORCID in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
   - family-names: Wu
     given-names: Qiusheng
+    orcid: http://orcid.org/0000-0001-5437-4073
 title: "Leafmap: A Python package for interactive mapping and geospatial analysis with minimal coding in a Jupyter environment"
 version: 0.3.5
 doi: 10.21105/joss.03414

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,6 @@ message: "If you use this software, please cite it as below."
 authors:
   - family-names: Wu
     given-names: Qiusheng
-    orcid: https://orcid.org/0000-0003-4925-7248
 title: "Leafmap: A Python package for interactive mapping and geospatial analysis with minimal coding in a Jupyter environment"
 version: 0.3.5
 doi: 10.21105/joss.03414

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
   - family-names: Wu
     given-names: Qiusheng
-    orcid: http://orcid.org/0000-0001-5437-4073
+    orcid: https://orcid.org/0000-0001-5437-4073
 title: "Leafmap: A Python package for interactive mapping and geospatial analysis with minimal coding in a Jupyter environment"
 version: 0.3.5
 doi: 10.21105/joss.03414


### PR DESCRIPTION
Hi @giswqs,

It seems that there is a copy'n'paste issue with your `CITATION.cff` file, as releases for leafmap are pushed to my ORCID account. Presumably the ORCID id wasn't changed, but left in from a copied example?

- The releases of this software show up under my ORCID profile, which is wrong as I'm not an author of this leafmap
- Removing the ORCID line also doesn't auto-push any new releases on Zenodo to ORCID
- Ideally, put in the relevant correct ORCID instead
- This PR replaces my id with the one taken from the JOSS paper