### PR TITLE
Removed nominatim URL from Search Control

### DIFF
--- a/docs/notebooks/32_local_tile.ipynb
+++ b/docs/notebooks/32_local_tile.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.add_local_tile(dem, palette='matplotlib.Viridis_10', layer_name=\"DEM\")"
+    "m.add_local_tile(dem, palette='viridis', layer_name=\"DEM\")"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/notebooks/43_search_control.ipynb
+++ b/docs/notebooks/43_search_control.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Search for any location around the world."
+    "Add a search control to the map. See the [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim)."
    ]
   },
   {
@@ -42,6 +42,8 @@
    "outputs": [],
    "source": [
     "m = leafmap.Map(draw_control=False)\n",
+    "url = \"https://nominatim.openstreetmap.org/search?format=json&q={s}\"\n",
+    "m.add_search_control(url)\n",
     "m"
    ]
   },
@@ -55,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "m = leafmap.Map(draw_control=False, layers_control=True)\n",

--- a/examples/notebooks/32_local_tile.ipynb
+++ b/examples/notebooks/32_local_tile.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.add_local_tile(dem, palette='matplotlib.Viridis_10', layer_name=\"DEM\")"
+    "m.add_local_tile(dem, palette='viridis', layer_name=\"DEM\")"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/43_search_control.ipynb
+++ b/examples/notebooks/43_search_control.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Search for any location around the world."
+    "Add a search control to the map. See the [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim)."
    ]
   },
   {
@@ -42,6 +42,8 @@
    "outputs": [],
    "source": [
     "m = leafmap.Map(draw_control=False)\n",
+    "url = \"https://nominatim.openstreetmap.org/search?format=json&q={s}\"\n",
+    "m.add_search_control(url)\n",
     "m"
    ]
   },
@@ -55,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "m = leafmap.Map(draw_control=False, layers_control=True)\n",

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -45,16 +45,12 @@ class Map(ipyleaflet.Map):
         self.tool_output_ctrl = None
         self.layer_control = None
         self.draw_control = None
+        self.search_control = None
         self.user_roi = None
         self.user_rois = None
         self.draw_features = []
         self.api_keys = {}
         self.geojson_layers = []
-        self.location_marker = ipyleaflet.Marker(
-            icon=ipyleaflet.AwesomeIcon(
-                name="check", marker_color="green", icon_color="darkred"
-            )
-        )
 
         # sandbox path for Voila app to restrict access to system directories.
         if "sandbox_path" not in kwargs:
@@ -89,11 +85,6 @@ class Map(ipyleaflet.Map):
             kwargs["fullscreen_control"] = True
         if kwargs["fullscreen_control"]:
             self.add_control(ipyleaflet.FullScreenControl())
-
-        if "search_control" not in kwargs:
-            kwargs["search_control"] = True
-        if kwargs["search_control"]:
-            self.add_search_control()
 
         if "draw_control" not in kwargs:
             kwargs["draw_control"] = True
@@ -1952,12 +1943,29 @@ class Map(ipyleaflet.Map):
         self.add_layer(geojson)
         self.geojson_layers.append(geojson)
 
-    def add_search_control(self):
+    def add_search_control(
+        self, url, marker=None, zoom=None, position="topleft", **kwargs
+    ):
+        """Adds a search control to the map.
+
+        Args:
+            url (str): The url to the search API. For example, "https://nominatim.openstreetmap.org/search?format=json&q={s}".
+            marker (ipyleaflet.Marker, optional): The marker to be used for the search result. Defaults to None.
+            zoom (int, optional): The zoom level to be used for the search result. Defaults to None.
+            position (str, optional): The position of the search control. Defaults to "topleft".
+            kwargs (dict, optional): Additional keyword arguments to be passed to the search control. See https://ipyleaflet.readthedocs.io/en/latest/api_reference/search_control.html
+        """
+        if marker is None:
+            marker = ipyleaflet.Marker(
+                icon=ipyleaflet.AwesomeIcon(
+                    name="check", marker_color="green", icon_color="darkred"
+                )
+            )
         search_control = ipyleaflet.SearchControl(
-            position="topleft",
-            url="https://nominatim.openstreetmap.org/search?format=json&q={s}",
-            zoom=5,
-            marker=self.location_marker,
+            position=position,
+            url=url,
+            zoom=zoom,
+            marker=marker,
         )
         self.add_control(search_control)
         self.search_control = search_control

--- a/leafmap/toolbar.py
+++ b/leafmap/toolbar.py
@@ -3458,7 +3458,6 @@ def search_geojson_gui(m=None):
     padding = "0px 0px 0px 5px"  # upper, right, bottom, left
     style = {"description_width": "initial"}
 
-    search_control = m.search_control
     if len(m.geojson_layers) > 0:
         geojson_layer_group = ipyleaflet.LayerGroup()
         for geojson_layer in m.geojson_layers:
@@ -3512,6 +3511,10 @@ def search_geojson_gui(m=None):
     buttons.style.button_width = "80px"
 
     output = widgets.Output(layout=widgets.Layout(width=widget_width, padding=padding))
+
+    if len(m.geojson_layers) == 0:
+        with output:
+            print("Please add vector data layers to the map before using this tool.")
 
     toolbar_widget = widgets.VBox()
     toolbar_widget.children = [toolbar_button]
@@ -3568,11 +3571,10 @@ def search_geojson_gui(m=None):
                 if m.tool_control is not None and m.tool_control in m.controls:
                     m.remove_control(m.tool_control)
                     m.tool_control = None
-                if len(m.geojson_layers) > 0:
+                if len(m.geojson_layers) > 0 and m.search_control is not None:
                     m.search_control.marker.visible = False
                     m.remove_control(m.search_control)
-                    m.add_control(search_control)
-                    m.search_control = search_control
+                    m.search_control = None
                     m.geojson_layer_group.clear_layers()
                     delattr(m, "geojson_layer_group")
 
@@ -3583,13 +3585,16 @@ def search_geojson_gui(m=None):
     def button_clicked(change):
         if change["new"] == "Apply":
             if len(m.geojson_layers) > 0 and attributes.value is not None:
-                if m.search_control.layer is None:
-                    m.remove_control(m.search_control)
+                if m.search_control is None:
                     geojson_control = ipyleaflet.SearchControl(
                         position="topleft",
                         layer=m.geojson_layer_group,
                         property_name=attributes.value,
-                        marker=m.location_marker,
+                        marker=ipyleaflet.Marker(
+                            icon=ipyleaflet.AwesomeIcon(
+                                name="check", marker_color="green", icon_color="darkred"
+                            )
+                        ),
                     )
                     m.add_control(geojson_control)
                     m.search_control = geojson_control
@@ -3608,11 +3613,10 @@ def search_geojson_gui(m=None):
                 if m.tool_control is not None and m.tool_control in m.controls:
                     m.remove_control(m.tool_control)
                     m.tool_control = None
-                if len(m.geojson_layers) > 0:
+                if len(m.geojson_layers) > 0 and m.search_control is not None:
                     m.search_control.marker.visible = False
                     m.remove_control(m.search_control)
-                    m.add_control(search_control)
-                    m.search_control = search_control
+                    m.search_control = None
                     if hasattr(m, "geojson_layer_group"):
                         m.geojson_layer_group.clear_layers()
                         delattr(m, "geojson_layer_group")


### PR DESCRIPTION
Per [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim), leafmap can't have the Nominatim URL hard coded in the package. Users can choose to add a search control by specifying a URL.  @martinRenou @martinfleis

```python
m = leafmap.Map()
url = "https://nominatim.openstreetmap.org/search?format=json&q={s}"
m.add_search_control(url)
m
```