### PR TITLE
Made mapclassify optional

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -5570,12 +5570,16 @@ def classify(
     """
 
     import warnings
-    import mapclassify
     import numpy as np
     import pandas as pd
     import geopandas as gpd
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+
+    try:
+        import mapclassify
+    except ImportError
+        raise ImportError("mapclassify is required for this function. Install with `pip install mapclassify`.")
 
     if isinstance(data, gpd.GeoDataFrame) or isinstance(data, pd.DataFrame):
         df = data

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ ipyfilechooser>=0.6.0
 ipyleaflet
 ipysheet
 jupyterlab>=3.0.0
-mapclassify>=2.4.0
 matplotlib
 numpy
 pandas

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ ipygany
 ipyvtklink
 laspy
 localtileserver
+mapclassify>=2.4.0
 mss
 netcdf4
 osmnx


### PR DESCRIPTION
This PR makes mapclassify optional to reduce the size of installed packages for leafmap.