### PR TITLE
Added support for changing geojson layer opacity

### DIFF
--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2125,6 +2125,17 @@ class Map(ipyleaflet.Map):
         self.add_layer(geojson)
         self.geojson_layers.append(geojson)
 
+        if not hasattr(self, "json_layer_dict"):
+            self.json_layer_dict = {}
+
+        params = {
+            "data": geojson,
+            "style": style,
+            "hover_style": hover_style,
+            "style_callback": style_callback,
+        }
+        self.json_layer_dict[layer_name] = params
+
     def add_search_control(
         self, url, marker=None, zoom=None, position="topleft", **kwargs
     ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gdown
 geojson
 ipyevents
 ipyfilechooser>=0.6.0
-ipyleaflet
+ipyleaflet>=0.17.0
 ipysheet
 jupyterlab>=3.0.0
 matplotlib


### PR DESCRIPTION
Thanks to ipyleaflet v0.17.0, leafmap now supports changing GeoJSON layer visibility and opacity interactively. 

@davidbrochart @martinRenou @jasongrout

```python
import leafmap
m = leafmap.Map()
m.add_basemap("CartoDB.DarkMatter")
in_geojson = 'https://raw.githubusercontent.com/giswqs/geemap/master/examples/data/cable-geo.geojson'
callback = lambda feat: {"color": "#" + feat["properties"]["color"], "weight": 2}
m.add_geojson(in_geojson, layer_name="Cable lines", style_callback=callback, info_mode=None)
m
```

![Peek 2022-07-08 14-57](https://user-images.githubusercontent.com/5016453/178054211-a6d1f6d0-82ff-4924-ac73-c71f0ddbcdfe.gif)

