### PR TITLE
Improve support for creating split-panel map

### DIFF
--- a/examples/notebooks/57_the_national_map.ipynb.ipynb
+++ b/examples/notebooks/57_the_national_map.ipynb.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "import leafmap\n",
     "\n",
-    "# If you are using a recently implemented leafmap feature that has not yet been released to PyPI or conda-forge, \n",
+    "# If you are using a recently implemented leafmap feature that has not yet been released to PyPI or conda-forge,\n",
     "# you can uncomment the following line to install the development version from GitHub.\n",
     "\n",
     "# leafmap.update_package()"
@@ -137,10 +137,10 @@
    "outputs": [],
    "source": [
     "params = {\n",
-    "          'q':'National Elevation Dataset (NED) 1/3 arc-second',\n",
-    "          'polyCode': '01010002',\n",
-    "          'polyType': 'huc8'\n",
-    "         }\n",
+    "    'q': 'National Elevation Dataset (NED) 1/3 arc-second',\n",
+    "    'polyCode': '01010002',\n",
+    "    'polyType': 'huc8',\n",
+    "}\n",
     "\n",
     "TNM.find_details(**params)['total']"
    ]
@@ -151,15 +151,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params = {'prodFormats':'LAS,LAZ', \n",
-    "          'datasets':'Lidar Point Cloud (LPC)',\n",
-    "          'polygon': [\n",
-    "                     (-104.94262695312236, 41.52867510196275),\n",
-    "                     (-102.83325195312291, 40.45065268246805),\n",
-    "                     (-104.94262695312236, 40.45065268246805),\n",
-    "                     (-104.94262695312236, 41.52867510196275),\n",
-    "                    ]\n",
-    "         }\n",
+    "params = {\n",
+    "    'prodFormats': 'LAS,LAZ',\n",
+    "    'datasets': 'Lidar Point Cloud (LPC)',\n",
+    "    'polygon': [\n",
+    "        (-104.94262695312236, 41.52867510196275),\n",
+    "        (-102.83325195312291, 40.45065268246805),\n",
+    "        (-104.94262695312236, 40.45065268246805),\n",
+    "        (-104.94262695312236, 41.52867510196275),\n",
+    "    ],\n",
+    "}\n",
     "\n",
     "TNM.find_details(**params)['total']"
    ]
@@ -221,13 +222,15 @@
    "outputs": [],
    "source": [
     "params = {\n",
-    "          'q':'National Elevation Dataset (NED) 1/3 arc-second',\n",
-    "          'polyCode': '01010002',\n",
-    "          'polyType': 'huc8',\n",
-    "          'max':2\n",
-    "         }\n",
+    "    'q': 'National Elevation Dataset (NED) 1/3 arc-second',\n",
+    "    'polyCode': '01010002',\n",
+    "    'polyType': 'huc8',\n",
+    "    'max': 2,\n",
+    "}\n",
     "\n",
-    "TNM.find_details(**params, offset=0)['items'][0] == TNM.find_details(**params, offset=1)['items'][0]"
+    "TNM.find_details(**params, offset=0)['items'][0] == TNM.find_details(\n",
+    "    **params, offset=1\n",
+    ")['items'][0]"
    ]
   },
   {
@@ -287,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bool(TNM.find_details(start='01-01-2010',q='NED', bbox=region))"
+    "bool(TNM.find_details(start='01-01-2010', q='NED', bbox=region))"
    ]
   },
   {
@@ -296,7 +299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bool(TNM.find_details(start='2021-12-01',end='2020-01-01',q='NED', bbox=region))"
+    "bool(TNM.find_details(start='2021-12-01', end='2020-01-01', q='NED', bbox=region))"
    ]
   },
   {
@@ -305,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bool(TNM.find_details(start='2021-12-01',end='2022-01-01',q='NED', bbox=region))"
+    "bool(TNM.find_details(start='2021-12-01', end='2022-01-01', q='NED', bbox=region))"
    ]
   },
   {
@@ -314,7 +317,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bool(TNM.find_details(start='2020-12-01',end='2022-01-01',q='NED', dateType='dateCreated', bbox=region))"
+    "bool(\n",
+    "    TNM.find_details(\n",
+    "        start='2020-12-01',\n",
+    "        end='2022-01-01',\n",
+    "        q='NED',\n",
+    "        dateType='dateCreated',\n",
+    "        bbox=region,\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -340,11 +351,11 @@
    "outputs": [],
    "source": [
     "params = {\n",
-    "          'q':'National Elevation Dataset (NED) 1/3 arc-second',\n",
-    "          'polyCode': '01010002',\n",
-    "          'polyType': 'huc8',\n",
-    "          'max':0\n",
-    "         }\n",
+    "    'q': 'National Elevation Dataset (NED) 1/3 arc-second',\n",
+    "    'polyCode': '01010002',\n",
+    "    'polyType': 'huc8',\n",
+    "    'max': 0,\n",
+    "}\n",
     "\n",
     "TNM.download_tiles(API=params)"
    ]
@@ -363,11 +374,11 @@
    "outputs": [],
    "source": [
     "params = {\n",
-    "          'q':'National Elevation Dataset (NED) 1/3 arc-second',\n",
-    "          'polyCode': '01010002',\n",
-    "          'polyType': 'huc8',\n",
-    "          'max':0\n",
-    "         }\n",
+    "    'q': 'National Elevation Dataset (NED) 1/3 arc-second',\n",
+    "    'polyCode': '01010002',\n",
+    "    'polyType': 'huc8',\n",
+    "    'max': 0,\n",
+    "}\n",
     "\n",
     "leafmap.download_tnm(API=params)"
    ]
@@ -380,7 +391,9 @@
    "source": [
     "region = [-115.9689, 35.9758, -115.3619, 36.4721]\n",
     "\n",
-    "leafmap.download_ned(region=region, return_url=True) == leafmap.download_tnm(region=region, return_url=True, API={'q':'NED'})"
+    "leafmap.download_ned(region=region, return_url=True) == leafmap.download_tnm(\n",
+    "    region=region, return_url=True, API={'q': 'NED'}\n",
+    ")"
    ]
   },
   {

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -3867,6 +3867,11 @@ def get_local_tile_layer(
         "localtileserver", URL="https://github.com/banesullivan/localtileserver"
     )
 
+    if "max_zoom" not in kwargs:
+        kwargs["max_zoom"] = 100
+    if "max_native_zoom" not in kwargs:
+        kwargs["max_native_zoom"] = 100
+
     # Make it compatible with binder and JupyterHub
     if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") is not None:
         os.environ[
@@ -3923,8 +3928,6 @@ def get_local_tile_layer(
             nodata=nodata,
             attribution=attribution,
             name=layer_name,
-            max_zoom=30,
-            max_native_zoom=30,
             **kwargs,
         )
     else:
@@ -3941,8 +3944,6 @@ def get_local_tile_layer(
             attr=attribution,
             overlay=True,
             name=layer_name,
-            max_zoom=30,
-            max_native_zoom=30,
             **kwargs,
         )
 

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -3879,6 +3879,9 @@ def get_local_tile_layer(
         TileClient,
     )
 
+    if "show_loading" not in kwargs:
+        kwargs["show_loading"] = False
+
     if isinstance(source, str):
         if not source.startswith("http"):
             if source.startswith("~"):
@@ -6554,3 +6557,181 @@ def reproject(image, output, dst_crs="EPSG:4326", resampling="nearest", **kwargs
                     resampling=resampling,
                     **kwargs,
                 )
+
+
+def image_check(image):
+
+    from localtileserver import TileClient
+
+    if isinstance(image, str):
+        if image.startswith("http") or os.path.exists(image):
+            pass
+        else:
+            raise ValueError("image must be a URL or filepath.")
+    elif isinstance(image, TileClient):
+        pass
+    else:
+        raise ValueError("image must be a URL or filepath.")
+
+
+def image_client(image, **kwargs):
+    """Get a LocalTileserver TileClient from an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        TileClient: A LocalTileserver TileClient.
+    """
+    image_check(image)
+
+    _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    return client
+
+
+def image_center(image, **kwargs):
+    """Get the center of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        tuple: A tuple of (latitude, longitude).
+    """
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    return client.center()
+
+
+def image_bounds(image, **kwargs):
+    """Get the bounds of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        list: A list of bounds in the form of [(south, west), (north, east)].
+    """
+
+    image_check(image)
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    bounds = client.bounds()
+    return [(bounds[0], bounds[2]), (bounds[1], bounds[3])]
+
+
+def image_metadata(image, **kwargs):
+    """Get the metadata of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        dict: A dictionary of image metadata.
+    """
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    return client.metadata()
+
+
+def image_bandcount(image, **kwargs):
+    """Get the number of bands in an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        int: The number of bands in the image.
+    """
+
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    return len(client.metadata()["bands"])
+
+
+def image_size(image, **kwargs):
+    """Get the size (width, height) of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        tuple: A tuple of (width, height).
+    """
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+
+    metadata = client.metadata()
+    return metadata["sourceSizeX"], metadata["sourceSizeY"]
+
+
+def image_projection(image, **kwargs):
+    """Get the projection of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        str: The projection of the image.
+    """
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    return client.metadata()["Projection"]
+
+
+def image_geotransform(image, **kwargs):
+    """Get the geotransform of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        list: A list of geotransform values.
+    """
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    return client.metadata()["GeoTransform"]
+
+
+def image_resolution(image, **kwargs):
+    """Get the resolution of an image.
+
+    Args:
+        image (str): The input image filepath or URL.
+
+    Returns:
+        float: The resolution of the image.
+    """
+    image_check(image)
+
+    if isinstance(image, str):
+        _, client = get_local_tile_layer(image, return_client=True, **kwargs)
+    else:
+        client = image
+    return client.metadata()["GeoTransform"][1]

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1010,35 +1010,67 @@ class Map(ipyleaflet.Map):
             )
             super().add_layer(marker)
 
-    def split_map(self, left_layer="HYBRID", right_layer="OpenStreetMap", **kwargs):
+    def split_map(
+        self,
+        left_layer="TERRAIN",
+        right_layer="OpenTopoMap",
+        left_args={},
+        right_args={},
+    ):
         """Adds split map.
 
         Args:
-            left_layer (str, optional): The layer tile layer. Defaults to 'HYBRID'.
-            right_layer (str, optional): The right tile layer. Defaults to 'OpenStreetMap'.
+            left_layer (str, optional): The left tile layer. Can be a local file path, HTTP URL, or a basemap name. Defaults to 'TERRAIN'.
+            right_layer (str, optional): The right tile layer. Can be a local file path, HTTP URL, or a basemap name. Defaults to 'OpenTopoMap'.
+            left_args (dict, optional): The arguments for the left tile layer. Defaults to {}.
+            right_args (dict, optional): The arguments for the right tile layer. Defaults to {}.
         """
-        if "max_zoom" not in kwargs:
-            kwargs["max_zoom"] = 100
-        if "max_native_zoom" not in kwargs:
-            kwargs["max_native_zoom"] = 100
+        if "max_zoom" not in left_args:
+            left_args["max_zoom"] = 100
+        if "max_native_zoom" not in left_args:
+            left_args["max_native_zoom"] = 100
+
+        if "max_zoom" not in right_args:
+            right_args["max_zoom"] = 100
+        if "max_native_zoom" not in right_args:
+            right_args["max_native_zoom"] = 100
+
+        if "layer_name" not in left_args:
+            left_args["layer_name"] = "Left Layer"
+
+        if "layer_name" not in right_args:
+            right_args["layer_name"] = "Right Layer"
+
+        bounds = None
+
         try:
             if left_layer in basemaps.keys():
                 left_layer = basemaps[left_layer]
             elif isinstance(left_layer, str):
                 if left_layer.startswith("http") and left_layer.endswith(".tif"):
                     url = cog_tile(left_layer)
+                    bbox = cog_bounds(left_layer)
+                    bounds = [(bbox[1], bbox[0]), (bbox[3], bbox[2])]
                     left_layer = ipyleaflet.TileLayer(
                         url=url,
                         name="Left Layer",
                         attribution=" ",
-                        **kwargs,
+                        **left_args,
                     )
+                elif os.path.exists(left_layer):
+                    left_layer, left_client = get_local_tile_layer(
+                        left_layer,
+                        tile_format="ipyleaflet",
+                        return_client=True,
+                        **left_args,
+                    )
+                    bounds = image_bounds(left_client)
                 else:
                     left_layer = ipyleaflet.TileLayer(
                         url=left_layer,
                         name="Left Layer",
                         attribution=" ",
-                        **kwargs,
+                        **left_args,
                     )
             elif isinstance(left_layer, ipyleaflet.TileLayer):
                 pass
@@ -1052,18 +1084,28 @@ class Map(ipyleaflet.Map):
             elif isinstance(right_layer, str):
                 if right_layer.startswith("http") and right_layer.endswith(".tif"):
                     url = cog_tile(right_layer)
+                    bbox = cog_bounds(right_layer)
+                    bounds = [(bbox[1], bbox[0]), (bbox[3], bbox[2])]
                     right_layer = ipyleaflet.TileLayer(
                         url=url,
                         name="Right Layer",
                         attribution=" ",
-                        **kwargs,
+                        **right_args,
                     )
+                elif os.path.exists(right_layer):
+                    right_layer, right_client = get_local_tile_layer(
+                        right_layer,
+                        tile_format="ipyleaflet",
+                        return_client=True,
+                        **right_args,
+                    )
+                    bounds = image_bounds(right_client)
                 else:
                     right_layer = ipyleaflet.TileLayer(
                         url=right_layer,
                         name="Right Layer",
                         attribution=" ",
-                        **kwargs,
+                        **right_args,
                     )
             elif isinstance(right_layer, ipyleaflet.TileLayer):
                 pass
@@ -1075,6 +1117,8 @@ class Map(ipyleaflet.Map):
                 left_layer=left_layer, right_layer=right_layer
             )
             self.add_control(control)
+            if bounds is not None:
+                self.fit_bounds(bounds)
 
         except Exception as e:
             print("The provided layers are invalid!")


### PR DESCRIPTION
This PR makes it easier to create a split-panel map with only one line of code. It supports any local or remote raster datasets. 

```python
import leafmap.foliumap as leafmap
m = leafmap.Map()
left = 'left.tif'     # a local file path or http url
right = 'right.tif'  # a local file path or http url
m.split_map(left, right)
m
```

Several image utilities functions are also added, such as 

- `image_center()`
- `image_bounds()`
- `image_size()`
- `image_resolution()`
- `image_metadata()`
- `image_projection()`
- `image_geotransform()`

Demo:
```python
m = leafmap.Map()
left = 'https://opendata.digitalglobe.com/events/california-fire-2020/pre-event/2018-02-16/pine-gulch-fire20/1030010076004E00.tif'
right = 'https://opendata.digitalglobe.com/events/california-fire-2020/post-event/2020-08-14/pine-gulch-fire20/10300100AAC8DD00.tif'
m.split_map(left, right)
m
```
![Peek 2022-11-02 00-20](https://user-images.githubusercontent.com/5016453/199395035-feefff53-8bbf-4b91-97eb-ef516a3bdecb.gif)
