### PR TITLE
Fixed kml bug

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -2241,10 +2241,11 @@ def kml_to_geojson(in_kml, out_geojson=None):
     check_package(name="geopandas", URL="https://geopandas.org")
 
     import geopandas as gpd
+    import fiona
 
     # import fiona
     # print(fiona.supported_drivers)
-    gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+    fiona.drvsupport.supported_drivers["KML"] = "rw"
     gdf = gpd.read_file(in_kml, driver="KML")
 
     if out_geojson is not None:
@@ -2416,6 +2417,7 @@ def vector_to_geojson(
     warnings.filterwarnings("ignore")
     check_package(name="geopandas", URL="https://geopandas.org")
     import geopandas as gpd
+    import fiona
 
     if not filename.startswith("http"):
         filename = os.path.abspath(filename)
@@ -2423,7 +2425,7 @@ def vector_to_geojson(
             filename = "zip://" + filename
     ext = os.path.splitext(filename)[1].lower()
     if ext == ".kml":
-        gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+        fiona.drvsupport.supported_drivers["KML"] = "rw"
         df = gpd.read_file(
             filename,
             bbox=bbox,

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -2201,10 +2201,10 @@ def kml_to_shp(in_kml, out_shp):
     check_package(name="geopandas", URL="https://geopandas.org")
 
     import geopandas as gpd
+    import fiona
 
-    # import fiona
     # print(fiona.supported_drivers)
-    gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+    fiona.drvsupport.supported_drivers["KML"] = "rw"
     df = gpd.read_file(in_kml, driver="KML")
     df.to_file(out_shp)
 
@@ -2624,12 +2624,13 @@ def vector_col_names(filename, **kwargs):
     warnings.filterwarnings("ignore")
     check_package(name="geopandas", URL="https://geopandas.org")
     import geopandas as gpd
+    import fiona
 
     if not filename.startswith("http"):
         filename = os.path.abspath(filename)
     ext = os.path.splitext(filename)[1].lower()
     if ext == ".kml":
-        gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+        fiona.drvsupport.supported_drivers["KML"] = "rw"
         gdf = gpd.read_file(filename, driver="KML", **kwargs)
     else:
         gdf = gpd.read_file(filename, **kwargs)


### PR DESCRIPTION
GeoPandas has changed the way to read kml. The previous method stopped working. The new way is: 

https://github.com/geopandas/geopandas/issues/2481

```python
import geopandas as gpd
import fiona

fiona.drvsupport.supported_drivers['KML'] = 'rw'
df = gpd.read_file('<filename>.kml', driver='KML')
```