### PR TITLE
Added function for downloading files using pyodide

### DIFF
--- a/docs/notebooks/48_lidar.ipynb
+++ b/docs/notebooks/48_lidar.ipynb
@@ -54,9 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = (\n",
-    "    'https://github.com/giswqs/data/raw/main/lidar/madison.zip'\n",
-    ")\n",
+    "url = 'https://github.com/giswqs/data/raw/main/lidar/madison.zip'\n",
     "filename = 'madison.las'"
    ]
   },

--- a/examples/batch_update.py
+++ b/examples/batch_update.py
@@ -33,7 +33,7 @@ for file in files:
 
     out_lines = []
     for index, line in enumerate(lines):
-        if 'colab-badge.svg' in line and 'jupyterlite' not in lines[index-1]:
+        if 'colab-badge.svg' in line and 'jupyterlite' not in lines[index - 1]:
             badge = (
                 '[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]'
             )
@@ -87,5 +87,9 @@ for file in files:
         f.writelines(out_lines)
 
 
-shutil.copytree(notebook_dir, notebook_dir.replace('examples', 'docs'), dirs_exist_ok=True)
-shutil.copytree(workshop_dir, workshop_dir.replace('examples', 'docs'), dirs_exist_ok=True)
+shutil.copytree(
+    notebook_dir, notebook_dir.replace('examples', 'docs'), dirs_exist_ok=True
+)
+shutil.copytree(
+    workshop_dir, workshop_dir.replace('examples', 'docs'), dirs_exist_ok=True
+)

--- a/examples/notebooks/48_lidar.ipynb
+++ b/examples/notebooks/48_lidar.ipynb
@@ -54,9 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = (\n",
-    "    'https://github.com/giswqs/data/raw/main/lidar/madison.zip'\n",
-    ")\n",
+    "url = 'https://github.com/giswqs/data/raw/main/lidar/madison.zip'\n",
     "filename = 'madison.las'"
    ]
   },

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -1179,7 +1179,20 @@ class Map(folium.Map):
             if isinstance(in_geojson, str):
 
                 if in_geojson.startswith("http"):
-                    data = requests.get(in_geojson).json()
+                    if is_jupyterlite():
+                        import pyodide
+
+                        output = os.path.basename(in_geojson)
+
+                        output = os.path.abspath(output)
+                        obj = pyodide.http.open_url(in_geojson)
+                        with open(output, 'w') as fd:
+                            shutil.copyfileobj(obj, fd)
+                        with open(output, 'r') as fd:
+                            data = json.load(fd)
+                    else:
+                        in_geojson = github_raw_url(in_geojson)
+                        data = requests.get(in_geojson).json()
                 else:
                     in_geojson = os.path.abspath(in_geojson)
                     if not os.path.exists(in_geojson):

--- a/leafmap/kepler.py
+++ b/leafmap/kepler.py
@@ -132,7 +132,20 @@ class Map(keplergl.KeplerGl):
             if isinstance(in_geojson, str):
 
                 if in_geojson.startswith("http"):
-                    data = requests.get(in_geojson).json()
+                    if is_jupyterlite():
+                        import pyodide
+
+                        output = os.path.basename(in_geojson)
+
+                        output = os.path.abspath(output)
+                        obj = pyodide.http.open_url(in_geojson)
+                        with open(output, 'w') as fd:
+                            shutil.copyfileobj(obj, fd)
+                        with open(output, 'r') as fd:
+                            data = json.load(fd)
+                    else:
+                        in_geojson = github_raw_url(in_geojson)
+                        data = requests.get(in_geojson).json()
                 else:
                     in_geojson = os.path.abspath(in_geojson)
                     if not os.path.exists(in_geojson):

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2089,8 +2089,21 @@ class Map(ipyleaflet.Map):
             if isinstance(in_geojson, str):
 
                 if in_geojson.startswith("http"):
-                    in_geojson = github_raw_url(in_geojson)
-                    data = requests.get(in_geojson).json()
+
+                    if is_jupyterlite():
+                        import pyodide
+
+                        output = os.path.basename(in_geojson)
+
+                        output = os.path.abspath(output)
+                        obj = pyodide.http.open_url(in_geojson)
+                        with open(output, 'w') as fd:
+                            shutil.copyfileobj(obj, fd)
+                        with open(output, 'r') as fd:
+                            data = json.load(fd)
+                    else:
+                        in_geojson = github_raw_url(in_geojson)
+                        data = requests.get(in_geojson).json()
                 else:
                     in_geojson = os.path.abspath(in_geojson)
                     if not os.path.exists(in_geojson):


### PR DESCRIPTION
Pyodide does not support the `requests` module. Therefore, all download file functions using requests would not work on JupyterLite. This PR adds the `download_file_lite()` functions for downloading plain text and binary files on JupyterLite. `Map.add_geojson()` should also work out of box now. 