### PR TITLE
Updated TiTiler endpoint

### DIFF
--- a/docs/notebooks/03_cog_stac.ipynb
+++ b/docs/notebooks/03_cog_stac.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3a2e4dd2",
    "metadata": {},
    "source": [
     "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/03_cog_stac.ipynb)\n",
@@ -16,6 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9218360c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "22698f71",
    "metadata": {},
    "source": [
     "**Working with Cloud Optimized GeoTIFF (COG)**\n",
@@ -44,6 +47,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a59dd84",
    "metadata": {},
    "source": [
     "![](https://i.imgur.com/pE4mxwf.gif)"
@@ -52,14 +56,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "897393e7",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import leafmap"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0c45299-4ac0-4259-84af-b517617a328c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['TITILER_ENDPOINT'] = 'https://titiler.xyz'  # Use the TiTiler demo endpoint. Replace this if needed."
+   ]
+  },
+  {
    "cell_type": "markdown",
+   "id": "0c5f9dd4",
    "metadata": {},
    "source": [
     "Create an interactive map."
@@ -68,6 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f0ad1525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,6 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cb168b55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,6 +104,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6a3901ce",
    "metadata": {},
    "source": [
     "Retrieve the bounding box coordinates of the COG file."
@@ -93,6 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0c66bcd6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,6 +122,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "207dfc9c",
    "metadata": {},
    "source": [
     "Retrieve the centroid coordinates of the COG file."
@@ -109,6 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "df1ff060",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,6 +140,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bce9085d",
    "metadata": {},
    "source": [
     "Retrieve the band names of the COG file."
@@ -125,6 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "91e86b68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,6 +158,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "977e02ed",
    "metadata": {},
    "source": [
     "Retrieves the tile layer URL of the COG file."
@@ -141,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6a2aa779",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,6 +176,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4cbeb1e1",
    "metadata": {},
    "source": [
     "Add a COG layer to the map."
@@ -157,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6b57f90d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,6 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2aca0768",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,6 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fd260122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,6 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "60821998",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,6 +224,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1915135",
    "metadata": {},
    "source": [
     "**Working with  SpatioTemporal Asset Catalog (STAC)**\n",
@@ -207,6 +240,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "275eff01",
    "metadata": {},
    "source": [
     "Create an interactive map."
@@ -215,6 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2d10d5b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,6 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a511a712",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,6 +268,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f59aebce",
    "metadata": {},
    "source": [
     "Retrieve the bounding box coordinates of the STAC file."
@@ -240,6 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a32c6a56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,6 +286,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "099be5d1",
    "metadata": {},
    "source": [
     "Retrieve the centroid coordinates of the STAC file."
@@ -256,6 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d2ab7fa5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,6 +304,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e11a1ff5",
    "metadata": {},
    "source": [
     "Retrieve the band names of the STAC file."
@@ -272,6 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2ec3472d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,6 +322,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59593a58",
    "metadata": {},
    "source": [
     "Retrieve the tile layer URL of the STAC file."
@@ -288,6 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "79704cef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,6 +340,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac2c24a0",
    "metadata": {},
    "source": [
     "Add a STAC layer to the map."
@@ -304,6 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b10f4ba3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,6 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "50885fec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,6 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e65ec17a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,6 +382,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/59_create_legend.ipynb
+++ b/docs/notebooks/59_create_legend.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import leafmap"
+    "import leafmap.foliumap as leafmap"
    ]
   },
   {

--- a/examples/notebooks/03_cog_stac.ipynb
+++ b/examples/notebooks/03_cog_stac.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3a2e4dd2",
    "metadata": {},
    "source": [
     "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/03_cog_stac.ipynb)\n",
@@ -16,6 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9218360c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "22698f71",
    "metadata": {},
    "source": [
     "**Working with Cloud Optimized GeoTIFF (COG)**\n",
@@ -44,6 +47,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a59dd84",
    "metadata": {},
    "source": [
     "![](https://i.imgur.com/pE4mxwf.gif)"
@@ -52,14 +56,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "897393e7",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import leafmap"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0c45299-4ac0-4259-84af-b517617a328c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['TITILER_ENDPOINT'] = 'https://titiler.xyz'  # Use the TiTiler demo endpoint. Replace this if needed."
+   ]
+  },
+  {
    "cell_type": "markdown",
+   "id": "0c5f9dd4",
    "metadata": {},
    "source": [
     "Create an interactive map."
@@ -68,6 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f0ad1525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,6 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cb168b55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,6 +104,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6a3901ce",
    "metadata": {},
    "source": [
     "Retrieve the bounding box coordinates of the COG file."
@@ -93,6 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0c66bcd6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,6 +122,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "207dfc9c",
    "metadata": {},
    "source": [
     "Retrieve the centroid coordinates of the COG file."
@@ -109,6 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "df1ff060",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,6 +140,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bce9085d",
    "metadata": {},
    "source": [
     "Retrieve the band names of the COG file."
@@ -125,6 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "91e86b68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,6 +158,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "977e02ed",
    "metadata": {},
    "source": [
     "Retrieves the tile layer URL of the COG file."
@@ -141,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6a2aa779",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,6 +176,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4cbeb1e1",
    "metadata": {},
    "source": [
     "Add a COG layer to the map."
@@ -157,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6b57f90d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,6 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2aca0768",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,6 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fd260122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,6 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "60821998",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,6 +224,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1915135",
    "metadata": {},
    "source": [
     "**Working with  SpatioTemporal Asset Catalog (STAC)**\n",
@@ -207,6 +240,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "275eff01",
    "metadata": {},
    "source": [
     "Create an interactive map."
@@ -215,6 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2d10d5b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,6 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a511a712",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,6 +268,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f59aebce",
    "metadata": {},
    "source": [
     "Retrieve the bounding box coordinates of the STAC file."
@@ -240,6 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a32c6a56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,6 +286,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "099be5d1",
    "metadata": {},
    "source": [
     "Retrieve the centroid coordinates of the STAC file."
@@ -256,6 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d2ab7fa5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,6 +304,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e11a1ff5",
    "metadata": {},
    "source": [
     "Retrieve the band names of the STAC file."
@@ -272,6 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2ec3472d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,6 +322,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59593a58",
    "metadata": {},
    "source": [
     "Retrieve the tile layer URL of the STAC file."
@@ -288,6 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "79704cef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,6 +340,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac2c24a0",
    "metadata": {},
    "source": [
     "Add a STAC layer to the map."
@@ -304,6 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b10f4ba3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,6 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "50885fec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,6 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e65ec17a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,6 +382,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/59_create_legend.ipynb
+++ b/examples/notebooks/59_create_legend.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import leafmap"
+    "import leafmap.foliumap as leafmap"
    ]
   },
   {

--- a/leafmap/bokehmap.py
+++ b/leafmap/bokehmap.py
@@ -125,7 +125,7 @@ class Map:
         url,
         attribution="",
         bands=None,
-        titiler_endpoint="https://titiler.xyz",
+        titiler_endpoint=None,
         cog_args={},
         fit_bounds=True,
         **kwargs,

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -126,10 +126,13 @@ def check_titiler_endpoint(titiler_endpoint=None):
         object: A titiler endpoint.
     """
     if titiler_endpoint is None:
-        if os.environ.get("TITILER_ENDPOINT") == "planetary-computer":
-            titiler_endpoint = PlanetaryComputerEndpoint()
+        if os.environ.get("TITILER_ENDPOINT") is not None:
+            titiler_endpoint = os.environ.get("TITILER_ENDPOINT")
+
+            if titiler_endpoint == "planetary-computer":
+                titiler_endpoint = PlanetaryComputerEndpoint()
         else:
-            titiler_endpoint = TitilerEndpoint()
+            titiler_endpoint = "https://titiler.xyz"
     elif titiler_endpoint in ["planetary-computer", "pc"]:
         titiler_endpoint = PlanetaryComputerEndpoint()
 
@@ -1007,7 +1010,7 @@ def create_code_cell(code="", where="below"):
     )
 
 
-def cog_tile(url, bands=None, titiler_endpoint="https://titiler.xyz", **kwargs):
+def cog_tile(url, bands=None, titiler_endpoint=None, **kwargs):
     """Get a tile layer from a Cloud Optimized GeoTIFF (COG).
         Source code adapted from https://developmentseed.org/titiler/examples/notebooks/Working_with_CloudOptimizedGeoTIFF_simple/
 
@@ -1021,6 +1024,8 @@ def cog_tile(url, bands=None, titiler_endpoint="https://titiler.xyz", **kwargs):
     Returns:
         tuple: Returns the COG Tile layer URL and bounds.
     """
+
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
 
     kwargs["url"] = url
 
@@ -1082,7 +1087,7 @@ def cog_tile(url, bands=None, titiler_endpoint="https://titiler.xyz", **kwargs):
 
 
 def cog_tile_vmin_vmax(
-    url, bands=None, titiler_endpoint="https://titiler.xyz", percentile=True, **kwargs
+    url, bands=None, titiler_endpoint=None, percentile=True, **kwargs
 ):
     """Get a tile layer from a Cloud Optimized GeoTIFF (COG) and return the minimum and maximum values.
 
@@ -1094,6 +1099,8 @@ def cog_tile_vmin_vmax(
     Returns:
         tuple: Returns the minimum and maximum values.
     """
+
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     stats = cog_stats(url, titiler_endpoint)
 
     if isinstance(bands, str):
@@ -1114,7 +1121,7 @@ def cog_tile_vmin_vmax(
 
 def cog_mosaic(
     links,
-    titiler_endpoint="https://titiler.xyz",
+    titiler_endpoint=None,
     username="anonymous",
     layername=None,
     overwrite=False,
@@ -1138,6 +1145,7 @@ def cog_mosaic(
         str: The tile URL for the COG mosaic.
     """
 
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     if layername is None:
         layername = "layer_" + random_string(5)
 
@@ -1179,7 +1187,7 @@ def cog_mosaic(
 def cog_mosaic_from_file(
     filepath,
     skip_rows=0,
-    titiler_endpoint="https://titiler.xyz",
+    titiler_endpoint=None,
     username="anonymous",
     layername=None,
     overwrite=False,
@@ -1202,6 +1210,7 @@ def cog_mosaic_from_file(
     """
     import urllib
 
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     links = []
     if filepath.startswith("http"):
         data = urllib.request.urlopen(filepath)
@@ -1220,7 +1229,7 @@ def cog_mosaic_from_file(
     return mosaic
 
 
-def cog_bounds(url, titiler_endpoint="https://titiler.xyz"):
+def cog_bounds(url, titiler_endpoint=None):
     """Get the bounding box of a Cloud Optimized GeoTIFF (COG).
 
     Args:
@@ -1231,6 +1240,7 @@ def cog_bounds(url, titiler_endpoint="https://titiler.xyz"):
         list: A list of values representing [left, bottom, right, top]
     """
 
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     r = requests.get(f"{titiler_endpoint}/cog/bounds", params={"url": url}).json()
 
     if "bounds" in r.keys():
@@ -1240,7 +1250,7 @@ def cog_bounds(url, titiler_endpoint="https://titiler.xyz"):
     return bounds
 
 
-def cog_center(url, titiler_endpoint="https://titiler.xyz"):
+def cog_center(url, titiler_endpoint=None):
     """Get the centroid of a Cloud Optimized GeoTIFF (COG).
 
     Args:
@@ -1250,12 +1260,13 @@ def cog_center(url, titiler_endpoint="https://titiler.xyz"):
     Returns:
         tuple: A tuple representing (longitude, latitude)
     """
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     bounds = cog_bounds(url, titiler_endpoint)
     center = ((bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2)  # (lat, lon)
     return center
 
 
-def cog_bands(url, titiler_endpoint="https://titiler.xyz"):
+def cog_bands(url, titiler_endpoint=None):
     """Get band names of a Cloud Optimized GeoTIFF (COG).
 
     Args:
@@ -1266,6 +1277,7 @@ def cog_bands(url, titiler_endpoint="https://titiler.xyz"):
         list: A list of band names
     """
 
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     r = requests.get(
         f"{titiler_endpoint}/cog/info",
         params={
@@ -1277,7 +1289,7 @@ def cog_bands(url, titiler_endpoint="https://titiler.xyz"):
     return bands
 
 
-def cog_stats(url, titiler_endpoint="https://titiler.xyz"):
+def cog_stats(url, titiler_endpoint=None):
     """Get band statistics of a Cloud Optimized GeoTIFF (COG).
 
     Args:
@@ -1288,6 +1300,7 @@ def cog_stats(url, titiler_endpoint="https://titiler.xyz"):
         list: A dictionary of band statistics.
     """
 
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     r = requests.get(
         f"{titiler_endpoint}/cog/statistics",
         params={
@@ -1298,7 +1311,7 @@ def cog_stats(url, titiler_endpoint="https://titiler.xyz"):
     return r
 
 
-def cog_info(url, titiler_endpoint="https://titiler.xyz", return_geojson=False):
+def cog_info(url, titiler_endpoint=None, return_geojson=False):
     """Get band statistics of a Cloud Optimized GeoTIFF (COG).
 
     Args:
@@ -1309,6 +1322,7 @@ def cog_info(url, titiler_endpoint="https://titiler.xyz", return_geojson=False):
         list: A dictionary of band info.
     """
 
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
     info = "info"
     if return_geojson:
         info = "info.geojson"
@@ -1328,7 +1342,7 @@ def cog_pixel_value(
     lat,
     url,
     bidx=None,
-    titiler_endpoint="https://titiler.xyz",
+    titiler_endpoint=None,
     verbose=True,
     **kwargs,
 ):
@@ -4859,8 +4873,7 @@ def mosaic_tile(url, titiler_endpoint=None, **kwargs):
         str: The tile URL.
     """
 
-    if titiler_endpoint is None:
-        titiler_endpoint = "https://titiler.xyz"
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
 
     if isinstance(url, str) and url.startswith("http"):
         kwargs["url"] = url
@@ -4889,8 +4902,7 @@ def mosaic_bounds(url, titiler_endpoint=None, **kwargs):
         list: A list of values representing [left, bottom, right, top]
     """
 
-    if titiler_endpoint is None:
-        titiler_endpoint = "https://titiler.xyz"
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
 
     if isinstance(url, str) and url.startswith("http"):
         kwargs["url"] = url
@@ -4919,8 +4931,7 @@ def mosaic_info(url, titiler_endpoint=None, **kwargs):
         dict: A dictionary containing bounds, center, minzoom, maxzoom, and name as keys.
     """
 
-    if titiler_endpoint is None:
-        titiler_endpoint = "https://titiler.xyz"
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
 
     if isinstance(url, str) and url.startswith("http"):
         kwargs["url"] = url
@@ -4949,8 +4960,7 @@ def mosaic_info_geojson(url, titiler_endpoint=None, **kwargs):
         dict: A dictionary representing a dict of GeoJSON.
     """
 
-    if titiler_endpoint is None:
-        titiler_endpoint = "https://titiler.xyz"
+    titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
 
     if isinstance(url, str) and url.startswith("http"):
         kwargs["url"] = url

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -843,7 +843,7 @@ class Map(folium.Map):
         opacity=1.0,
         shown=True,
         bands=None,
-        titiler_endpoint="https://titiler.xyz",
+        titiler_endpoint=None,
         **kwargs,
     ):
         """Adds a COG TileLayer to the map.

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -779,7 +779,7 @@ class Map(ipyleaflet.Map):
         opacity=1.0,
         shown=True,
         bands=None,
-        titiler_endpoint="https://titiler.xyz",
+        titiler_endpoint=None,
         **kwargs,
     ):
         """Adds a COG TileLayer to the map.

--- a/leafmap/plotlymap.py
+++ b/leafmap/plotlymap.py
@@ -398,7 +398,7 @@ class Map(go.FigureWidget):
         attribution="",
         opacity=1.0,
         bands=None,
-        titiler_endpoint="https://titiler.xyz",
+        titiler_endpoint=None,
         **kwargs,
     ):
         """Adds a COG TileLayer to the map.


### PR DESCRIPTION
This PR updates the TiTiler endpoint, allowing it to be specified as an environment variable, such as `os.environ("TITILER_ENDPOINT")='https://your-endpoint' `