### PR TITLE
Add support for vector tiles

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -2633,6 +2633,41 @@ class Map(folium.Map):
 
         self.add_html(text, position=position, **kwargs)
 
+    def add_vector_tile(
+        self,
+        url,
+        attribution="",
+        styles={},
+        layer_name="Vector Tile",
+        **kwargs,
+    ):
+        """Adds a VectorTileLayer to the map. It wraps the folium.plugins.VectorGridProtobuf class. See
+            https://github.com/python-visualization/folium/blob/main/folium/plugins/vectorgrid_protobuf.py#L7
+
+        Args:
+            url (str, optional): The URL of the tile layer, such as
+                'https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w'.
+            attribution (str, optional): The attribution to use. Defaults to ''.
+            styles (dict,optional): Style dict, specific to the vector tile source.
+            layer_name (str, optional): The layer name to use for the layer. Defaults to 'Vector Tile'.
+            kwargs: Additional keyword arguments to pass to the ipyleaflet.VectorTileLayer class.
+        """
+
+        options = {}
+
+        for key, value in kwargs.items():
+            options[key] = value
+
+        if "vector_tile_layer_styles" in options:
+            styles = options["vector_tile_layer_styles"]
+            del options["vector_tile_layer_styles"]
+
+        if styles:
+            options["vectorTileLayerStyles"] = styles
+
+        vc = plugins.VectorGridProtobuf(url, layer_name, options)
+        self.add_child(vc)
+
     def remove_labels(self, **kwargs):
         """Removes a layer from the map."""
         print("The folium plotting backend does not support removing labels.")
@@ -2674,18 +2709,6 @@ class Map(folium.Map):
         slider_length="150px",
     ):
         """Adds a time slider to the map."""
-        raise NotImplementedError(
-            "The folium plotting backend does not support this function. Use the ipyleaflet plotting backend instead."
-        )
-
-    def add_vector_tile_layer(
-        self,
-        url="https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w",
-        attribution="",
-        vector_tile_layer_styles=dict(),
-        **kwargs,
-    ):
-        """Adds a VectorTileLayer to the map."""
         raise NotImplementedError(
             "The folium plotting backend does not support this function. Use the ipyleaflet plotting backend instead."
         )

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -348,6 +348,15 @@ class Map(ipyleaflet.Map):
             self.remove_layer(existing_layer)
         super().add_layer(layer)
 
+    def add_layer_control(self, position="topright"):
+        """Adds a layer control to the map.
+
+        Args:
+            position (str, optional): The position of the layer control. Defaults to 'topright'.
+        """        
+
+        self.add(ipyleaflet.LayersControl(position=position))
+
     def layer_opacity(self, name, value=1.0):
         """Changes layer opacity.
 
@@ -446,32 +455,43 @@ class Map(ipyleaflet.Map):
             print("Failed to add the specified TileLayer.")
             raise Exception(e)
 
-    def add_vector_tile_layer(
+    def add_vector_tile(
         self,
-        url="https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w",
+        url,
         attribution="",
-        vector_tile_layer_styles=dict(),
+        styles={},
+        layer_name="Vector Tile",
         **kwargs,
     ):
-        """Adds a VectorTileLayer to the map.
+        """Adds a VectorTileLayer to the map. It wraps the ipyleaflet.VectorTileLayer class. See
+            https://ipyleaflet.readthedocs.io/en/latest/layers/vector_tile.html
 
         Args:
-            url (str, optional): The URL of the tile layer. Defaults to 'https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w'.
+            url (str, optional): The URL of the tile layer, such as
+                'https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w'.
             attribution (str, optional): The attribution to use. Defaults to ''.
-            vector_tile_layer_styles (dict,optional): Style dict, specific to the vector tile source.
+            styles (dict,optional): Style dict, specific to the vector tile source.
+            layer_name (str, optional): The layer name to use for the layer. Defaults to 'Vector Tile'.
+            kwargs: Additional keyword arguments to pass to the ipyleaflet.VectorTileLayer class.
         """
+        if "vector_tile_layer_styles" in kwargs:
+            styles = kwargs["vector_tile_layer_styles"]
+            del kwargs["vector_tile_layer_styles"]
         try:
             vector_tile_layer = ipyleaflet.VectorTileLayer(
                 url=url,
                 attribution=attribution,
-                vector_tile_layer_styles=vector_tile_layer_styles,
+                vector_tile_layer_styles=styles,
                 **kwargs,
             )
+            vector_tile_layer.name = layer_name
             self.add_layer(vector_tile_layer)
 
         except Exception as e:
             print("Failed to add the specified VectorTileLayer.")
             raise Exception(e)
+
+    add_vector_tile_layer = add_vector_tile
 
     def add_osm_from_geocode(
         self,

--- a/leafmap/toolbar.py
+++ b/leafmap/toolbar.py
@@ -517,8 +517,10 @@ def main_toolbar(m):
                         )
                     except KeyError:
                         opacity = 1.0
-                else:
+                elif hasattr(layer, "opacity"):
                     opacity = layer.opacity
+                else:
+                    opacity = 1.0
 
                 layer_opacity = widgets.FloatSlider(
                     value=opacity,
@@ -560,7 +562,7 @@ def main_toolbar(m):
 
                 if layer in m.geojson_layers:
                     layer_opacity.observe(layer_opacity_changed, "value")
-                else:
+                elif hasattr(layer, "opacity"):
                     widgets.jsdlink((layer_opacity, "value"), (layer, "opacity"))
 
                 # widgets.jsdlink((layer_opacity, "value"), (layer, "opacity"))

--- a/tests/test_foliumap.py
+++ b/tests/test_foliumap.py
@@ -327,16 +327,6 @@ class TestFoliumap(unittest.TestCase):
         out_str = m.to_html()
         assert "Countries" in out_str
 
-    def test_add_vector_tile_layer(self):
-        """Check adding vector tile layer"""
-        with self.assertRaises(NotImplementedError):
-            m = leafmap.Map()
-            url = "https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w"
-            attribution = "Nextzen"
-            m.add_vector_tile_layer(url, attribution)
-            out_str = m.to_html()
-            assert "Nextzen" in out_str
-
     def test_add_wms_layer(self):
         """Check adding WMS layer"""
         m = leafmap.Map()

--- a/tests/test_leafmap.py
+++ b/tests/test_leafmap.py
@@ -330,12 +330,12 @@ class TestLeafmap(unittest.TestCase):
         out_str = m.to_html()
         assert "Countries" in out_str
 
-    def test_add_vector_tile_layer(self):
+    def test_add_vector_tile(self):
         """Check adding vector tile layer"""
         m = leafmap.Map()
         url = "https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w"
         attribution = "Nextzen"
-        m.add_vector_tile_layer(url, attribution)
+        m.add_vector_tile(url, attribution)
         out_str = m.to_html()
         assert "Nextzen" in out_str
 


### PR DESCRIPTION
This PR adds support for rendering vector tiles. 

For ipyleaflet
```python
import leafmap
m = leafmap.Map()
url = "https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w"
m.add_vector_tile(url, layer_name='Vector Tile')
m
```

For folium

```python
import leafmap.foliumap as leafmap
m = leafmap.Map()
url = "https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w"
m.add_vector_tile(url, layer_name='Vector Tile')
m
```

Note that the ipyleaflet vector tile layer does support `opacity` or `visible` attributes. 
Also, the folium VectorGridProtobuf does not work properly with LayerControl
https://github.com/python-visualization/folium/issues/1716