### PR TITLE
Add default_vis option to cog_tile() function

### DIFF
--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -195,6 +195,9 @@ def cog_tile(url, bands=None, titiler_endpoint=None, **kwargs):
         TileMatrixSetId = kwargs["TileMatrixSetId"]
         kwargs.pop("TileMatrixSetId")
 
+    if 'default_vis' in kwargs.keys() and kwargs['default_vis']:
+        kwargs = {"url": url}
+
     r = requests.get(
         f"{titiler_endpoint}/cog/{TileMatrixSetId}/tilejson.json", params=kwargs
     ).json()


### PR DESCRIPTION
By default, `Map.add_cog_layer()` adds a `rescale` parameter to a single band raster to achieve an optimal visualization. This might not be ideal for some COG files with a built-in colormap in it, such as as land cover maps. This PR adds a `default_vis` parameter to the function to force leafmap to use the built-in colormap from the data. 

Update your package using `leafmap.update_package()` and restart the kernel to take effect. This improvement will be included in the next leafmap release. 

```python
import leafmap
m = leafmap.Map()
url = 'https://data.mundialis.de/geodata/lulc-germany/classification_2021/classification_map_germany_2021_v01_COG.tif'
m.add_cog_layer(url, name='LULC Germany 2021', default_vis=True)
m
```
![image](https://user-images.githubusercontent.com/5016453/222247327-63eed7a5-e0bb-4e92-ae54-b605dfd8fcf1.png)

