### PR TITLE
Remove mkdocs search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,15 +30,15 @@ theme:
         - navigation.instant
         - navigation.tracking
         - navigation.top
-        - search.highlight
-        - search.share
+        # - search.highlight
+        # - search.share
     custom_dir: "docs/overrides"
     font:
         text: Google Sans
         code: Regular
 
 plugins:
-    - search
+    # - search
     - mkdocstrings
     - git-revision-date
     - git-revision-date-localized:


### PR DESCRIPTION
The large `search_index.json` file (~50 Mb) generated by `mkdocs-jupyter` makes the website unresponsive. The PR removes the mkdocs search and replace it with Google search. 

https://github.com/giswqs/geemap/issues/1437