### PR TITLE
Remove ipykernel import

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.18.8 - Mar 26, 2023
+
+**Improvement**
+
+-   Removed ipykernel import ([#402](https://github.com/giswqs/leafmap/pull/402))
+
 ## v0.18.7 - Mar 24, 2023
 
 **New Features**

--- a/leafmap/deck.py
+++ b/leafmap/deck.py
@@ -3,7 +3,7 @@ from .common import *
 from .osm import *
 from .leafmap import basemaps
 from . import examples
-import ipykernel.ipkernel
+
 
 try:
     import pydeck as pdk

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -2,7 +2,7 @@ import os
 import folium
 import folium.plugins as plugins
 from box import Box
-import ipykernel.ipkernel
+
 from .common import *
 from .legends import builtin_legends
 from .basemaps import xyz_to_folium

--- a/leafmap/heremap.py
+++ b/leafmap/heremap.py
@@ -9,7 +9,7 @@ import random
 import requests
 import warnings
 import ipywidgets as widgets
-import ipykernel.ipkernel
+
 from box import Box
 from .basemaps import xyz_to_heremap
 from .common import shp_to_geojson, gdf_to_geojson, vector_to_geojson, random_string

--- a/leafmap/kepler.py
+++ b/leafmap/kepler.py
@@ -3,7 +3,7 @@ import os
 import sys
 import requests
 import ipywidgets as widgets
-import ipykernel.ipkernel
+
 import pandas as pd
 from IPython.display import display, HTML
 from .common import *

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2,7 +2,7 @@
 
 import os
 import ipyleaflet
-import ipykernel.ipkernel
+
 from box import Box
 from IPython.display import display
 from .basemaps import xyz_to_leaflet

--- a/leafmap/plotlymap.py
+++ b/leafmap/plotlymap.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import pandas as pd
 import ipywidgets as widgets
-import ipykernel.ipkernel
+
 from .basemaps import xyz_to_plotly
 from .common import *
 from .osm import *


### PR DESCRIPTION
The ipywidgets bug has been fixed upstream. This PR remove the ipykernel import to avoid the JupyterLite import error #402