### PR TITLE
Set toolbar widget visibility with env variables

### DIFF
--- a/leafmap/toolbar.py
+++ b/leafmap/toolbar.py
@@ -311,6 +311,9 @@ def main_toolbar(m):
 
     icons = list(tools.keys())
     tooltips = [item["tooltip"] for item in list(tools.values())]
+    toolnames = [item["name"].upper() for item in list(all_tools.values())]
+    toolnames.sort()
+    setattr(m, "_ENV_VARS", toolnames)
 
     icon_width = "32px"
     icon_height = "32px"

--- a/leafmap/toolbar.py
+++ b/leafmap/toolbar.py
@@ -214,7 +214,7 @@ def main_toolbar(m):
     Args:
         m (leafmap.Map): The leafmap Map object.
     """
-    tools = {
+    all_tools = {
         "map": {
             "name": "basemap",
             "tooltip": "Change basemap",
@@ -303,6 +303,11 @@ def main_toolbar(m):
     #     for item in voila_tools:
     #         if item in tools.keys():
     #             del tools[item]
+
+    tools = {}
+    for tool in all_tools:
+        if os.environ.get(all_tools[tool]['name'].upper(), "").upper() != "FALSE":
+            tools[tool] = all_tools[tool]
 
     icons = list(tools.keys())
     tooltips = [item["tooltip"] for item in list(tools.values())]


### PR DESCRIPTION
Users can set environment variables to determine which widget to show on the toolbar. 

```python
import os
import leafmap
os.environ['TIMESLIDER'] = 'FALSE'
os.environ['WHITEBOX'] = 'FALSE'
os.environ['SPLIT_MAP'] = 'FALSE'
m = leafmap.Map()
m
```


```bash
export TIMESLIDER=FALSE
export WHITEBOX=FALSE
export SPLIT_MAP=FALSE
```